### PR TITLE
Add USDT Lite (USDTL)

### DIFF
--- a/blockchains/smartchain/assets/0x90832b8536D802807288431AAd5810Ee7Ae074b7/tags.json
+++ b/blockchains/smartchain/assets/0x90832b8536D802807288431AAd5810Ee7Ae074b7/tags.json
@@ -1,0 +1,3 @@
+[
+  "stablecoin"
+]


### PR DESCRIPTION
This PR adds logo and metadata for the USDT Lite (USDTL) BEP-20 token on Binance Smart Chain.
Token contract: 0x90832b8536d802807288431aad5810ee7ae074b7
Website: https://usdtl.finance
