### PR TITLE
Add BJF Token (BEP20) – 0xd5bab4c1b92176f9690c0d2771edbf18b73b8181

### DIFF
--- a/token.json
+++ b/token.json
@@ -1,0 +1,17 @@
+{
+  "name": "Benjamin Franklin Token",
+  "symbol": "BJF",
+  "type": "token",
+  "decimals": 18,
+  "chainId": 56,
+  "status": "active",
+  "id": "0xd5bab4c1b92176f9690c0d2771edbf18b73b8181",
+  "website": "https://www.bjftoken.com",
+  "description": "Benjamin Franklin Token (BJF) is a decentralized digital asset inspired by the spirit of innovation and freedom, built on BNB Smart Chain.",
+  "explorer": "https://bscscan.com/token/0xd5bab4c1b92176f9690c0d2771edbf18b73b8181",
+  "links": {
+    "telegram": "https://t.me/benjaminfranklintoken",
+    "twitter": "https://twitter.com/bjftoken"
+  },
+  "tags": ["meme", "community", "airdrop"]
+}


### PR DESCRIPTION
This PR adds the Benjamin Franklin Token (BJF) to the TrustWallet assets list.

Token details:
- Name: Benjamin Franklin Token
- Symbol: BJF
- Chain: Binance Smart Chain (BEP20)
- Decimals: 18
- Contract address: 0xd5bab4c1b92176f9690c0d2771edbf18b73b8181

All required files are included:
- logo.png (256x256 PNG)
- info.json with accurate metadata

Thank you for reviewing our request.