### PR TITLE
Add WealthAI (WAI) Token on Base

### DIFF
--- a/blockchains/base/assets/0xb7D17C61242b8659e186bBC2E96Dc9D5a524c3Db/info.json
+++ b/blockchains/base/assets/0xb7D17C61242b8659e186bBC2E96Dc9D5a524c3Db/info.json
@@ -1,0 +1,11 @@
+{
+  "name": "WealthAI",
+  "symbol": "WAI",
+  "decimals": 18,
+  "description": "WealthAI is an AI-powered DeFi asset optimizing investor wealth using algorithmic intelligence and dynamic financial strategies.",
+  "website": "https://wealthaitoken.com",
+  "telegram": "https://t.me/Official_WealthAI_BOT",
+  "twitter": "https://x.com/wealth_ai_token",
+  "explorer": "https://basescan.org/token/0xb7D17C61242b8659e186bBC2E96Dc9D5a524c3Db"
+}
+


### PR DESCRIPTION
This PR adds the WealthAI (WAI) token to the Base network in the Trust Wallet asset registry.

- Token contract: `0xb7D17C61242b8659e186bBC2E96Dc9D5a524c3Db`
- Chain: Base
- Symbol: WAI
- Name: WealthAI
- Decimals: 18
- Logo: 32x32 PNG
- Website: https://github.com/OfficialGIGA/WealthAI
- Twitter: https://x.com/wealth_ai_token?s=21
- Telegram: https://t.me/Official_WealthAI_BOT
