### PR TITLE
Add Io Beats (IOB) token on Base

### DIFF
--- a/blockchains/base/assets/0x80A23f168831D6e1f0a1353DbF3a75CAE16cb709
+++ b/blockchains/base/assets/0x80A23f168831D6e1f0a1353DbF3a75CAE16cb709
@@ -1,0 +1,11 @@
+{
+  "name": "Io Beats",
+  "symbol": "IOB",
+  "type": "ERC20",
+  "decimals": 18,
+  "description": "Io Beats (IOB) is a decentralized token built on Base L2 for music and community-driven innovation.",
+  "website": "https://open.iobeats.com/",
+  "explorer": "https://basescan.org/token/0x80A23f168831d6e1f0a1353DbF3a75CAE16cb709",
+  "status": "active",
+  "id": "0x80A23f168831D6e1f0a1353DbF3a75CAE16cb709"
+}


### PR DESCRIPTION
This PR adds the Io Beats (IOB) token to the Base blockchain assets.
- Contract: 0x80A23f168831D6e1f0a1353DbF3a75CAE16cb709
- Decimals: 18
- Website: https://open.iobeats.com/
- Explorer: https://basescan.org/token/0x80A23f168831D6e1f0a1353DbF3a75CAE16cb709
