### PR TITLE
Add BITQ logo and info.json

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -1,0 +1,12 @@
+blockchains/smartchain/assets/0xed15Bc681Cf264F4A3cAE02A43FE8C9CE88163C0/info.json
+{
+  "name": "BitQueen",
+  "symbol": "BITQ",
+  "type": "BEP20",
+  "decimals": 18,
+  "description": "BitQueen is a decentralized token built on Binance Smart Chain.",
+  "website": "https://yourwebsite.com",
+  "explorer": "https://bscscan.com/token/0xed15Bc681Cf264F4A3cAE02A43FE8C9CE88163C0",
+  "status": "active",
+  "id": "0xed15Bc681Cf264F4A3cAE02A43FE8C9CE88163C0"
+}


### PR DESCRIPTION
Add info.json for BitQueen (BITQ)
This PR adds logo.png and info.json for BitQueen (BITQ) token.
Contract address: 0xed15Bc681Cf264F4A3cAE02A43FE8C9CE88163C0