### PR TITLE
HubChannel token info and logo

### DIFF
--- a/blockchains/smartchain/assets/0xC4805cCD095c77a634940c48Ef7048534D6586Aa
+++ b/blockchains/smartchain/assets/0xC4805cCD095c77a634940c48Ef7048534D6586Aa
@@ -1,1 +1,12 @@
+{
+  "name": "HubChannel",
+  "symbol": "HBC",
+  "type": "BEP20",
+  "decimals": 18,
+  "description": "HubChannel platform token for OTC, payments, and utility functions.",
+  "website": "https://your-website.com",
+  "explorer": "https://bscscan.com/token/0xC4805cCD095c77a634940c48Ef7048534D6586Aa",
+  "status": "active",
+  "id": "0xC4805cCD095c77a634940c48Ef7048534D6586Aa"
+}
 


### PR DESCRIPTION
This PR adds the HubChannel (HBC) BEP20 token info.json and logo.
Contract: 0xC4805cCD095c77a634940c48Ef7048534D6586Aa