### PR TITLE
Mark GhostwareOS (GHOST) in Solana as SCAM

### DIFF
--- a/blockchains/solana/assets/BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST/info.json
+++ b/blockchains/solana/assets/BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "SCAM GhostwareOS",
+    "type": "SPL",
+    "symbol": "SCAM GHOST",
+    "decimals": 9,
+    "description": "This token is malicious do not interact",
+    "website": "https://solscan.io/token/BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST",
+    "explorer": "https://solscan.io/token/BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST",
+    "status": "spam",
+    "id": "BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST"
+}


### PR DESCRIPTION
## Token Marked as SCAM

This PR marks the token as malicious.

- **Name**: SCAM GhostwareOS
- **Symbol**: SCAM GHOST
- **Type**: SCAM
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags