### PR TITLE
Mark FAKE BASE (FAKE BASE) in Base as SCAM

### DIFF
--- a/blockchains/base/assets/0x73326b4d0225c429bed050c11c4422d91470aaf4/info.json
+++ b/blockchains/base/assets/0x73326b4d0225c429bed050c11c4422d91470aaf4/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "SCAM FAKE BASE",
+    "type": "BASE",
+    "symbol": "SCAM FAKE BASE",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://basescan.org/token/0x73326b4d0225c429bed050c11c4422d91470aaf4",
+    "explorer": "https://basescan.org/token/0x73326b4d0225c429bed050c11c4422d91470aaf4",
+    "status": "spam",
+    "id": "0x73326b4d0225c429bed050c11c4422d91470aaf4"
+}


### PR DESCRIPTION
[sc-129323123]
## Token Marked as SCAM

This PR marks the token as malicious.

- **Name**: SCAM FAKE BASE
- **Symbol**: SCAM FAKE BASE
- **Type**: SCAM
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags