### PR TITLE
Mark Lucid USDT (LUSDT) in Polygon as SCAM

### DIFF
--- a/blockchains/polygon/assets/0xD14d06cC2b464E92348310893b94F0855d9e3dc4/info.json
+++ b/blockchains/polygon/assets/0xD14d06cC2b464E92348310893b94F0855d9e3dc4/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "SCAM Lucid USDT",
+    "type": "POLYGON",
+    "symbol": "SCAM LUSDT",
+    "decimals": 6,
+    "description": "This token is malicious do not interact",
+    "website": "https://polygonscan.com/token/0xD14d06cC2b464E92348310893b94F0855d9e3dc4",
+    "explorer": "https://polygonscan.com/token/0xD14d06cC2b464E92348310893b94F0855d9e3dc4",
+    "status": "spam",
+    "id": "0xD14d06cC2b464E92348310893b94F0855d9e3dc4"
+}


### PR DESCRIPTION
[sc-12345678]
## Token Marked as SCAM

This PR marks the token as malicious.

- **Name**: SCAM Lucid USDT
- **Symbol**: SCAM LUSDT
- **Type**: SCAM
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags