### PR TITLE
Mark CryptoRose (CROSE) in Smartchain as SCAM

### DIFF
--- a/blockchains/smartchain/assets/0xa862bdC2dB5FeD053C3C30D35DFEB326c1acdeC4/info.json
+++ b/blockchains/smartchain/assets/0xa862bdC2dB5FeD053C3C30D35DFEB326c1acdeC4/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "SCAM CryptoRose",
+    "type": "BEP20",
+    "symbol": "SCAM CROSE",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://bscscan.com/token/0xa862bdC2dB5FeD053C3C30D35DFEB326c1acdeC4",
+    "explorer": "https://bscscan.com/token/0xa862bdC2dB5FeD053C3C30D35DFEB326c1acdeC4",
+    "status": "spam",
+    "id": "0xa862bdC2dB5FeD053C3C30D35DFEB326c1acdeC4"
+}


### PR DESCRIPTION
## Token Marked as SCAM

This PR marks the token as malicious.

- **Name**: SCAM CryptoRose
- **Symbol**: SCAM CROSE
- **Type**: SCAM
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags