### PR TITLE
Mark Chain Games (bCHAIN) in Smartchain as SCAM

### DIFF
--- a/blockchains/smartchain/assets/0x35DE111558F691F77f791fb0c08b2D6B931A9d47/info.json
+++ b/blockchains/smartchain/assets/0x35DE111558F691F77f791fb0c08b2D6B931A9d47/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "SCAM Chain Games",
+    "type": "BEP20",
+    "symbol": "SCAM bCHAIN",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "",
+    "explorer": "",
+    "status": "spam",
+    "id": "0x35DE111558F691F77f791fb0c08b2D6B931A9d47"
+}


### PR DESCRIPTION
## Token Marked as SCAM

This PR marks the token as malicious.

- **Name**: SCAM Chain Games
- **Symbol**: SCAM bCHAIN
- **Type**: SCAM
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags