### PR TITLE
Mark ABCD (ABCD) in Ethereum as FAKE

### DIFF
--- a/blockchains/ethereum/assets/0x6df1C1E379bC5a00a7b4C6e67A203333772f45A8wdad/info.json
+++ b/blockchains/ethereum/assets/0x6df1C1E379bC5a00a7b4C6e67A203333772f45A8wdad/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE ABCD",
+    "type": "ERC20",
+    "symbol": "FAKE ABCD",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://etherscan.io/token/0x6df1c1e379bc5a00a7b4c6e67a203333772f45a8",
+    "explorer": "https://etherscan.io/token/0x6df1c1e379bc5a00a7b4c6e67a203333772f45a8",
+    "status": "spam",
+    "id": "0x6df1C1E379bC5a00a7b4C6e67A203333772f45A8wdad"
+}


### PR DESCRIPTION
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE ABCD
- **Symbol**: FAKE ABCD
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags