### PR TITLE
Mark ADADDA (ADADDA) in Solana as SCAM

### DIFF
--- a/blockchains/solana/assets/BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST/info.json
+++ b/blockchains/solana/assets/BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "SCAM ADADDA",
+    "type": "SPL",
+    "symbol": "SCAM ADADDA",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://etherscan.io/token/BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST",
+    "explorer": "https://etherscan.io/token/BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST",
+    "status": "spam",
+    "id": "BBKPiLM9KjdJW7oQSKt99RVWcZdhF6sEHRKnwqeBGHST"
+}


### PR DESCRIPTION
[sc-12321321]
## Token Marked as SCAM

This PR marks the token as malicious.

- **Name**: SCAM ADADDA
- **Symbol**: SCAM ADADDA
- **Type**: SCAM
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags