### PR TITLE
Mark Bork (BORK) in Solana as SCAM

### DIFF
--- a/blockchains/solana/assets/4jZXkSNgTQKCDb36ECZ6a2aNzcUniGcDeXgTdtM2HxAX/info.json
+++ b/blockchains/solana/assets/4jZXkSNgTQKCDb36ECZ6a2aNzcUniGcDeXgTdtM2HxAX/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "SCAM Bork",
+    "type": "SPL",
+    "symbol": "SCAM BORK",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://solscan.io/token/4jZXkSNgTQKCDb36ECZ6a2aNzcUniGcDeXgTdtM2HxAX",
+    "explorer": "https://solscan.io/token/4jZXkSNgTQKCDb36ECZ6a2aNzcUniGcDeXgTdtM2HxAX",
+    "status": "spam",
+    "id": "4jZXkSNgTQKCDb36ECZ6a2aNzcUniGcDeXgTdtM2HxAX"
+}


### PR DESCRIPTION
[sc-1231323]
## Token Marked as SCAM

This PR marks the token as malicious.

- **Name**: SCAM Bork
- **Symbol**: SCAM BORK
- **Type**: SCAM
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags