### PR TITLE
Mark Classic USDC (USDC) in Smartchain as FAKE

### DIFF
--- a/blockchains/smartchain/assets/0x7DB54758503c25200B331131C219acD64CFa74c8/info.json
+++ b/blockchains/smartchain/assets/0x7DB54758503c25200B331131C219acD64CFa74c8/info.json
@@ -3,9 +3,9 @@
     "type": "BEP20",
     "symbol": "FAKE USDC",
     "decimals": 18,
-    "description": "This token is malicious do not interact",
+    "description": "This token/project is abandoned.",
     "website": "https://bscscan.com/token/0x7DB54758503c25200B331131C219acD64CFa74c8",
     "explorer": "https://bscscan.com/token/0x7DB54758503c25200B331131C219acD64CFa74c8",
-    "status": "spam",
+    "status": "abandoned",
     "id": "0x7DB54758503c25200B331131C219acD64CFa74c8"
 }


### PR DESCRIPTION
[sc-107551]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE Classic USDC
- **Symbol**: FAKE USDC
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags