### PR TITLE
Mark FAKE USDT (FAKE USDT) in Solana as FAKE

### DIFF
--- a/blockchains/solana/assets/ES9k2ZdqJmoYhAHdTa9Bq1XmJjQnTNWqHgKTEVg5zvNb/info.json
+++ b/blockchains/solana/assets/ES9k2ZdqJmoYhAHdTa9Bq1XmJjQnTNWqHgKTEVg5zvNb/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE FAKE USDT",
+    "type": "SPL",
+    "symbol": "FAKE FAKE USDT",
+    "decimals": 6,
+    "description": "This token is malicious do not interact",
+    "website": "https://solscan.io/token/ES9k2ZdqJmoYhAHdTa9Bq1XmJjQnTNWqHgKTEVg5zvNb",
+    "explorer": "https://solscan.io/token/ES9k2ZdqJmoYhAHdTa9Bq1XmJjQnTNWqHgKTEVg5zvNb",
+    "status": "spam",
+    "id": "ES9k2ZdqJmoYhAHdTa9Bq1XmJjQnTNWqHgKTEVg5zvNb"
+}


### PR DESCRIPTION
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE FAKE USDT
- **Symbol**: FAKE FAKE USDT
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags