### PR TITLE
[SECURITY] Multi-chain scam tokens dataset (Arta Security Lab)

### DIFF
--- a/blockchains/scam-dataset/info.json
+++ b/blockchains/scam-dataset/info.json
@@ -1,0 +1,24 @@
+{
+  "last_update": "2026-04-23",
+  "source": "Arta Security Lab",
+  "type": "scam_token_dataset",
+  "tokens": [
+    {"network":"solana","address":"EqBwbzaRPwP8R4TSoHcF5u3daZcEmkpVeJEK3nKGAnNJ","symbol":"USDT","risk":"high"},
+    {"network":"solana","address":"4zpV5uq3Uc5GpiuujFX5EJD3CJhiELUSawMTW6Ha9age","symbol":"USDT","risk":"high"},
+    {"network":"solana","address":"4hyvTS9P4Y4FkfZn2WSvsA1tucm47wMbrmM9rNVDdhMr","symbol":"USDT","risk":"high"},
+    {"network":"solana","address":"GHdqveWq74KFU7qguj7AM4i8HtzzZtAF4Tt8LfXV1Yn3","symbol":"USD.T","risk":"high"},
+    {"network":"solana","address":"51CVRGtyrV9DF3cbJ6xNxmjyvFFEyE2PLDraRqQU4Cu6","symbol":"USDT.T","risk":"high"},
+    {"network":"solana","address":"JACymcU6sL18DRabJP9MHYCrUrim5pkUSbvKx3Y35HXz","symbol":"USDT","risk":"high"},
+
+    {"network":"ethereum","address":"0x7fF317158a3C437675Ee1F027C407AbF92968201","symbol":"USD.T","risk":"high"},
+    {"network":"ethereum","address":"0x099E9E6a2252B952931EDa64950E87Bc73861594","symbol":"USD.T","risk":"high"},
+    {"network":"ethereum","address":"0x267B66243463427C101caBDA4adAfe64c380CA89","symbol":"USD.C","risk":"high"},
+    {"network":"ethereum","address":"0x6F8aAD52c0127aE0B676BDDEe340A24Afec5fC8E","symbol":"USDT.T","risk":"high"},
+
+    {"network":"bsc","address":"0x332C0F58763E3990204B780d33237DF4524d6d09","symbol":"USDT.T","risk":"high"},
+    {"network":"arbitrum","address":"0x6d011934C23B44559F237bF4C28A8919906C5955","symbol":"USD.T","risk":"high"},
+
+    {"network":"tron","address":"TKBuv1du4NnrevTCvpvpr7oAaiVcnRntNE","symbol":"USD.T","risk":"high"},
+    {"network":"tron","address":"TQZzxARTUFFMvWbVp7mZnjFA6CetQqT9z8","symbol":"USDT.T","risk":"high"}
+  ]
+}

--- a/blockchains/solana/assets/3ijco7rKKeuyDbLTMYBFKvJm15811iLi4diUYjbXJMAt/info.json
+++ b/blockchains/solana/assets/3ijco7rKKeuyDbLTMYBFKvJm15811iLi4diUYjbXJMAt/info.json
@@ -1,0 +1,9 @@
+{
+  "name": "Fake USDC.A",
+  "symbol": "USDC.A",
+  "type": "SPL",
+  "status": "malicious",
+  "description": "Fake USDC.A impersonation token flagged by Arta Security Lab",
+  "website": "https://github.com/artablok/crypto-security-research",
+  "explorer": "https://solscan.io/token/3ijco7rKKeuyDbLTMYBFKvJm15811iLi4diUYjbXJMAt"
+}

--- a/blockchains/solana/assets/4zpV5uq3Uc5GpiuujFX5EJD3CJhiELUSawMTW6Ha9age/info.json
+++ b/blockchains/solana/assets/4zpV5uq3Uc5GpiuujFX5EJD3CJhiELUSawMTW6Ha9age/info.json
@@ -1,0 +1,11 @@
+{
+  "name": "Fake USDT",
+  "symbol": "SPAM USDT",
+  "type": "SPL",
+  "decimals": 6,
+  "description": "This token is malicious do not interact.",
+  "website": "https://explorer.solana.com/address/4zpV5uq3Uc5GpiuujFX5EJD3CJhiELUSawMTW6Ha9age",
+  "explorer": "https://explorer.solana.com/address/4zpV5uq3Uc5GpiuujFX5EJD3CJhiELUSawMTW6Ha9age",
+  "status": "spam",
+  "id": "4zpV5uq3Uc5GpiuujFX5EJD3CJhiELUSawMTW6Ha9age"
+}

--- a/blockchains/solana/assets/7koyaGqHPpdEAxWQdFH9GHVW8jC4zwXgA3rFcrM1wkBK/info.json
+++ b/blockchains/solana/assets/7koyaGqHPpdEAxWQdFH9GHVW8jC4zwXgA3rFcrM1wkBK/info.json
@@ -1,0 +1,9 @@
+{
+  "name": "Fake EURC",
+  "symbol": "EURC",
+  "type": "SPL",
+  "status": "malicious",
+  "description": "Fake EURC token impersonation flagged by Arta Security Lab",
+  "website": "https://github.com/artablok/crypto-security-research",
+  "explorer": "https://solscan.io/token/7koyaGqHPpdEAxWQdFH9GHVW8jC4zwXgA3rFcrM1wkBK"
+}

--- a/blockchains/solana/assets/EqBwbzaRPwP8R4TSoHcF5u3daZcEmkpVeJEK3nKGAnNJ/info.json
+++ b/blockchains/solana/assets/EqBwbzaRPwP8R4TSoHcF5u3daZcEmkpVeJEK3nKGAnNJ/info.json
@@ -1,0 +1,9 @@
+{
+  "name": "Fake USDT",
+  "symbol": "USDT",
+  "type": "SPL",
+  "status": "malicious",
+  "description": "Impersonation token flagged by Arta Security Lab",
+  "website": "https://github.com/artablok/crypto-security-research",
+  "explorer": "https://solscan.io/token/EqBwbzaRPwP8R4TSoHcF5u3daZcEmkpVeJEK3nKGAnNJ"
+}

--- a/blockchains/solana/assets/Vr1UbnDPTGT4AxmW6tVRQwSnMwzT9vo82pjmcCnuqtz
+++ b/blockchains/solana/assets/Vr1UbnDPTGT4AxmW6tVRQwSnMwzT9vo82pjmcCnuqtz
@@ -1,0 +1,9 @@
+{
+  "name": "Fake USDT",
+  "symbol": "USDT",
+  "type": "SPL",
+  "status": "malicious",
+  "description": "Impersonation token flagged by Arta Security Lab",
+  "website": "https://github.com/artablok/crypto-security-research",
+  "explorer": "https://solscan.io/token/Vr1UbnDPTGT4AxmW6tVRQwSnMwzT9vo82pjmcCnuqtz"
+}

--- a/blockchains/solana/scam/arta-scam-report-1.md
+++ b/blockchains/solana/scam/arta-scam-report-1.md
@@ -1,0 +1,47 @@
+# 🚨 Arta Security Lab – Scam Token Report
+
+## Network: Solana + EVM
+
+We have identified multiple malicious tokens impersonating well-known stablecoins (USDT, USDC, EURC).
+
+These tokens are actively used in phishing and dust attacks targeting wallet users.
+
+---
+
+## 🔴 Solana Tokens
+
+- 3ijco7rKKeuyDbLTMYBFKvJm15811iLi4diUYjbXJMAt (Fake USDC.A)
+- Vr1UbnDPTGT4AxmW6tVRQwSnMwzT9vo82pjmcCnuqtz (Fake USDT)
+- 7koyaGqHPpdEAxWQdFH9GHVW8jC4zwXgA3rFcrM1wkBK (Fake EURC)
+- 4zpV5uq3Uc5GpiuujFX5EJD3CJhiELUSawMTW6Ha9age (Fake USDT)
+- GLTjENvmRTWspotyXFFDDjkiESFTgQQCaNxH7D3gGnyb (Fake USDT)
+- 7HahXZBKzQZ7VBk1BTwXVeJu3Y1AQagYa2gKb9bB8Buv (Fake USDC)
+
+---
+
+## 🔴 EVM Token
+
+- 0xC12BbdD66DDDb8212Ffa05C7cA952ac628660B6E (Fake USDT.T)
+
+---
+
+## ⚠️ Risk Assessment
+
+- Type: Scam / Impersonation
+- Risk Level: HIGH
+- Attack Vector: Dust + Social Engineering
+
+---
+
+## 📡 Source
+
+Arta Security Lab  
+https://artablockchain.in
+
+---
+
+## 📌 Recommendation
+
+- Immediate blacklist
+- Wallet warning flags
+- Pattern-based detection for similar tokens


### PR DESCRIPTION
## Security Report – Scam Tokens

This PR contains a structured dataset of confirmed scam tokens across multiple networks.

Networks affected:
- Solana
- Ethereum / EVM
- BNB Chain / Arbitrum
- TRON

These tokens:
- impersonate USDT / USDC
- are distributed via airdrops
- redirect users to phishing resources

⚠️ Approximately 80% of these tokens are still visible in Trust Wallet.

Previous PR was closed without review:
https://github.com/trustwallet/assets/pull/36385

This is a security report.

Requesting review from security team.