### PR TITLE
Add stablecoin tag to USDC variants missing it

### DIFF
--- a/blockchains/binance/assets/USDC-CD2/info.json
+++ b/blockchains/binance/assets/USDC-CD2/info.json
@@ -7,5 +7,8 @@
     "website": "https://binance.org",
     "explorer": "https://explorer.binance.org/asset/USDC-CD2",
     "status": "active",
-    "id": "USDC-CD2"
+    "id": "USDC-CD2",
+    "tags": [
+        "stablecoin"
+    ]
 }

--- a/blockchains/heco/assets/0x9362Bbef4B8313A8Aa9f0c9808B80577Aa26B73B/info.json
+++ b/blockchains/heco/assets/0x9362Bbef4B8313A8Aa9f0c9808B80577Aa26B73B/info.json
@@ -10,7 +10,8 @@
     "id": "0x9362Bbef4B8313A8Aa9f0c9808B80577Aa26B73B",
     "tags": [
         "defi",
-        "heco-tag"
+        "heco-tag",
+        "stablecoin"
     ],
     "links": [
         {

--- a/blockchains/kcc/assets/0x980a5AfEf3D17aD98635F6C5aebCBAedEd3c3430/info.json
+++ b/blockchains/kcc/assets/0x980a5AfEf3D17aD98635F6C5aebCBAedEd3c3430/info.json
@@ -17,5 +17,8 @@
             "name": "whitepaper",
             "url": "https://f.hubspotusercontent30.net/hubfs/9304636/PDF/centre-whitepaper.pdf"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/mantle/assets/0xEB466342C4d449BC9f53A865D5Cb90586f405215/info.json
+++ b/blockchains/mantle/assets/0xEB466342C4d449BC9f53A865D5Cb90586f405215/info.json
@@ -17,5 +17,8 @@
             "name": "discord",
             "url": "https://discord.com/invite/aRZ3Ra6f7D"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/info.json
+++ b/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/info.json
@@ -29,5 +29,8 @@
             "name": "coingecko",
             "url": "https://coingecko.com/en/coins/usd-coin/"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/polygon/assets/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359/info.json
+++ b/blockchains/polygon/assets/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359/info.json
@@ -29,5 +29,8 @@
             "name": "coingecko",
             "url": "https://coingecko.com/en/coins/usd-coin/"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/solana/assets/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/info.json
+++ b/blockchains/solana/assets/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/info.json
@@ -17,5 +17,8 @@
             "name": "x",
             "url": "https://x.com/solanabeach_io"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/sonic/assets/0x29219dd400f2Bf60E5a23d13Be72B486D4038894/info.json
+++ b/blockchains/sonic/assets/0x29219dd400f2Bf60E5a23d13Be72B486D4038894/info.json
@@ -17,5 +17,8 @@
             "name": "coinmarketcap",
             "url": "https://coinmarketcap.com/currencies/usd-coin/"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/tron/assets/TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8/info.json
+++ b/blockchains/tron/assets/TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8/info.json
@@ -17,5 +17,8 @@
             "name": "x",
             "url": "https://x.com/centre_io"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }


### PR DESCRIPTION
## Summary

Add the `"stablecoin"` tag to 9 native/bridged USDC `info.json` files that were missing it, so these assets can be correctly identified as stablecoins by downstream consumers.

## Files updated

| Chain | Asset | Path |
|---|---|---|
| Solana (SPL) | USDC | `blockchains/solana/assets/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
| Tron (TRC20) | USDC | `blockchains/tron/assets/TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8` |
| Polygon | Native USDC (PoS) | `blockchains/polygon/assets/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
| Polygon | Bridged USDC.e (PoS) | `blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174` |
| Binance Chain (BEP2) | USDC | `blockchains/binance/assets/USDC-CD2` |
| KCC (KRC20) | KCC-Peg USDC | `blockchains/kcc/assets/0x980a5AfEf3D17aD98635F6C5aebCBAedEd3c3430` |
| Mantle | Axelar Wrapped USDC (axlUSDC) | `blockchains/mantle/assets/0xEB466342C4d449BC9f53A865D5Cb90586f405215` |
| Sonic | Bridged USDC.e | `blockchains/sonic/assets/0x29219dd400f2Bf60E5a23d13Be72B486D4038894` |
| HECO (HRC20) | Heco-Peg USDC | `blockchains/heco/assets/0x9362Bbef4B8313A8Aa9f0c9808B80577Aa26B73B` |

For HECO the existing `defi` / `heco-tag` entries are preserved; `stablecoin` is appended.

## Motivation

All listed assets are fiat-pegged USDC (native issuance or canonical bridged representations). Marking them with the `stablecoin` tag aligns them with other USDC deployments in this repo (ERC20, BEP20, Base, Arbitrum, Optimism, Avalanche, etc.) that are already tagged.