### PR TITLE
Add stablecoin tag to USDC/USDT variants missing it

### DIFF
--- a/blockchains/kcc/assets/0x0039f574eE5cC39bdD162E9A88e3EB1f111bAF48/info.json
+++ b/blockchains/kcc/assets/0x0039f574eE5cC39bdD162E9A88e3EB1f111bAF48/info.json
@@ -17,5 +17,8 @@
             "name": "whitepaper",
             "url": "https://tether.to/en/transparency/"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/kcc/assets/0x980a5AfEf3D17aD98635F6C5aebCBAedEd3c3430/info.json
+++ b/blockchains/kcc/assets/0x980a5AfEf3D17aD98635F6C5aebCBAedEd3c3430/info.json
@@ -17,5 +17,8 @@
             "name": "whitepaper",
             "url": "https://f.hubspotusercontent30.net/hubfs/9304636/PDF/centre-whitepaper.pdf"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/opbnb/assets/0x9e5AAC1Ba1a2e6aEd6b32689DFcF62A509Ca96f3/info.json
+++ b/blockchains/opbnb/assets/0x9e5AAC1Ba1a2e6aEd6b32689DFcF62A509Ca96f3/info.json
@@ -21,5 +21,8 @@
             "name": "coinmarketcap",
             "url": "https://coinmarketcap.com/ru/currencies/tether/"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/polygon/assets/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359/info.json
+++ b/blockchains/polygon/assets/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359/info.json
@@ -29,5 +29,8 @@
             "name": "coingecko",
             "url": "https://coingecko.com/en/coins/usd-coin/"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F/info.json
+++ b/blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F/info.json
@@ -21,5 +21,8 @@
             "name": "coinmarketcap",
             "url": "https://coinmarketcap.com/ru/currencies/tether/"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/solana/assets/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/info.json
+++ b/blockchains/solana/assets/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/info.json
@@ -17,5 +17,8 @@
             "name": "x",
             "url": "https://x.com/solanabeach_io"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/solana/assets/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB/info.json
+++ b/blockchains/solana/assets/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB/info.json
@@ -25,5 +25,8 @@
             "name": "whitepaper",
             "url": "https://tether.to/wp-content/uploads/2016/06/TetherWhitePaper.pdf"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/solana/assets/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB/info.json
+++ b/blockchains/solana/assets/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB/info.json
@@ -1,5 +1,5 @@
 {
-    "name": "USDT",
+    "name": "Tether USDT",
     "symbol": "USDT",
     "type": "SPL",
     "decimals": 6,

--- a/blockchains/solana/tokenlist.json
+++ b/blockchains/solana/tokenlist.json
@@ -407,7 +407,7 @@
             "asset": "c501_tEs9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
             "type": "SPL",
             "address": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-            "name": "USDT",
+            "name": "Tether USDT",
             "symbol": "USDT",
             "decimals": 6,
             "logoURI": "https://assets-cdn.trustwallet.com/blockchains/solana/assets/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB/logo.png",

--- a/blockchains/tron/assets/TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8/info.json
+++ b/blockchains/tron/assets/TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8/info.json
@@ -17,5 +17,8 @@
             "name": "x",
             "url": "https://x.com/centre_io"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/tron/assets/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t/info.json
+++ b/blockchains/tron/assets/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t/info.json
@@ -37,5 +37,8 @@
             "name": "facebook",
             "url": "https://facebook.com/tronfoundation"
         }
+    ],
+    "tags": [
+        "stablecoin"
     ]
 }

--- a/blockchains/tron/assets/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t/info.json
+++ b/blockchains/tron/assets/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t/info.json
@@ -1,5 +1,5 @@
 {
-    "name": "Tether",
+    "name": "Tether USDT",
     "website": "https://tether.to",
     "description": "Tether (USDT) is a cryptocurrency with a value meant to mirror the value of the U.S. dollar.",
     "explorer": "https://tronscan.io/#/token20/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",


### PR DESCRIPTION
## Summary

Add the `"stablecoin"` tag to 8 USDC / USDT `info.json` files that were missing it, so these assets can be correctly identified as stablecoins by downstream consumers.

## Files updated

### USDC

| Chain | Name | Path |
|---|---|---|
| Polygon | Native USDC (PoS) | `blockchains/polygon/assets/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
| Tron (TRC20) | USDC | `blockchains/tron/assets/TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8` |
| KCC (KRC20) | KCC-Peg USDC | `blockchains/kcc/assets/0x980a5AfEf3D17aD98635F6C5aebCBAedEd3c3430` |

### USDT

| Chain | Name | Path |
|---|---|---|
| Solana (SPL) | Tether USDT | `blockchains/solana/assets/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB` |
| Tron (TRC20) | Tether | `blockchains/tron/assets/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` |
| Polygon | (PoS) Tether USD | `blockchains/polygon/assets/0xc2132D05D31c914a87C6611C10748AEb04B58e8F` |
| KCC (KRC20) | KCC-Peg Tether USD | `blockchains/kcc/assets/0x0039f574eE5cC39bdD162E9A88e3EB1f111bAF48` |
| opBNB | Tether USD | `blockchains/opbnb/assets/0x9e5AAC1Ba1a2e6aEd6b32689DFcF62A509Ca96f3` |

## Motivation

All listed assets are fiat-pegged USDC / USDT (native issuance or canonical bridged representations). Marking them with the `stablecoin` tag aligns them with other USDC / USDT deployments in this repo (ERC20, BEP20, Base, Arbitrum, Optimism, Avalanche, etc.) that are already tagged, so stablecoin-aware consumers don't skip over these chains.