### PR TITLE
Add DVGAS (DirvenBank Gas) token

### DIFF
--- a/blockchains/gnosis/assets/0x3C1ECB059d8B79402420e84cA17FFbBe1264eBd8/info.json
+++ b/blockchains/gnosis/assets/0x3C1ECB059d8B79402420e84cA17FFbBe1264eBd8/info.json
@@ -1,0 +1,8 @@
+{
+  "address": "0x3C1ECB059d8B79402420e84cA17FFbBe1264eBd8",
+  "chainId": 100,
+  "decimals": 18,
+  "name": "DirvenBank Gas",
+  "symbol": "DVGAS",
+  "logoURI": "https://raw.githubusercontent.com/dirven/assets/main/dvgas.png"
+}

--- a/tokens/gnosis.json
+++ b/tokens/gnosis.json
@@ -1,0 +1,18 @@
+{
+  "chainId": 100,
+  "address": "0x3C1ECB059d8B79402420e84cA17FFbBe1264eBd8",
+  "symbol": "DVGAS",
+  "name": "DirvenBank Gas",
+  "decimals": 18,
+  "logoURI": "https://raw.githubusercontent.com/dirven/assets/main/dvgas.png",
+  "tags": [
+    {
+      "id": "gas",
+      "name": "Gas Token"
+    }
+  ],
+  "extensions": {
+    "website": "https://dirven.bank",
+    "description": "DirvenBank - Cross-chain arbitrage system"
+  }
+}


### PR DESCRIPTION
## Add DVGAS (DirvenBank Gas) token to list

- Address: 0x3C1ECB059d8B79402420e84cA17FFbBe1264eBd8
- Chain: Gnosis (chainId: 100)

DirvenBank - Cross-chain arbitrage system
Website: https://dirven.bank
