### PR TITLE
Add info.json for BitTorrent token on TRON

### DIFF
--- a/blockchains/tron/assets/TNB8EYSxAyFBD8oBGZFBDRJMjmnhZoTLnv/info.json
+++ b/blockchains/tron/assets/TNB8EYSxAyFBD8oBGZFBDRJMjmnhZoTLnv/info.json
@@ -1,0 +1,11 @@
+{
+      "name": "BitTorrent",
+      "website": "https://www.bittorrent.com",
+      "description": "BitTorrent is a popular peer-to-peer (P2P) file sharing protocol that has been around since 2001. In 2018, it was acquired by the TRON Foundation, and shortly after, the BTT token was launched on the TRON blockchain.",
+      "explorer": "https://tronscan.org/#/token20/TNB8EYSxAyFBD8oBGZFBDRJMjmnhZoTLnv",
+      "type": "TRC20",
+      "symbol": "BTT",
+      "decimals": 6,
+      "status": "active",
+      "id": "TNB8EYSxAyFBD8oBGZFBDRJMjmnhZoTLnv"
+}


### PR DESCRIPTION
This PR adds the BitTorrent (BTT) TRC20 token information to the blockchains/tron/assets directory. The info.json file contains accurate details for the token.