### PR TITLE
Add MyrxWallet Network chain + WMRT/MUSD/WBTC tokens (Chain 8472)

### DIFF
--- a/blockchains/myrxwallet/assets/0x00e69754c21090d69D29a2abe3B6CF153D3F1dF7/info.json
+++ b/blockchains/myrxwallet/assets/0x00e69754c21090d69D29a2abe3B6CF153D3F1dF7/info.json
@@ -1,0 +1,12 @@
+{
+    "name": "Wrapped MRT",
+    "symbol": "WMRT",
+    "type": "ERC20",
+    "decimals": 18,
+    "description": "Wrapped MRT (WMRT) is the ERC-20 wrapped form of the native MRT token on MyrxWallet Network. Used for DeFi trading on MyrxSwap.",
+    "website": "https://myrxwallet.io",
+    "explorer": "https://explorer.myrxwallet.io/address/0x00e69754c21090d69D29a2abe3B6CF153D3F1dF7",
+    "status": "active",
+    "id": "0x00e69754c21090d69D29a2abe3B6CF153D3F1dF7",
+    "tags": ["wrapped", "defi", "healthcare"]
+}

--- a/blockchains/myrxwallet/assets/0x4dE82fE635bEA34D9de0C18E49bEE39E8B46c4dF/info.json
+++ b/blockchains/myrxwallet/assets/0x4dE82fE635bEA34D9de0C18E49bEE39E8B46c4dF/info.json
@@ -1,0 +1,12 @@
+{
+    "name": "Wrapped Bitcoin",
+    "symbol": "WBTC",
+    "type": "ERC20",
+    "decimals": 8,
+    "description": "Wrapped Bitcoin (WBTC) on MyrxWallet Network. BTC-backed token for DeFi trading on MyrxSwap.",
+    "website": "https://myrxwallet.io",
+    "explorer": "https://explorer.myrxwallet.io/address/0x4dE82fE635bEA34D9de0C18E49bEE39E8B46c4dF",
+    "status": "active",
+    "id": "0x4dE82fE635bEA34D9de0C18E49bEE39E8B46c4dF",
+    "tags": ["wrapped", "bitcoin", "defi"]
+}

--- a/blockchains/myrxwallet/assets/0x9c5e5b03e5ac5D789e59Ce7D5F6e5e43f8c9BAD2/info.json
+++ b/blockchains/myrxwallet/assets/0x9c5e5b03e5ac5D789e59Ce7D5F6e5e43f8c9BAD2/info.json
@@ -1,0 +1,12 @@
+{
+    "name": "MyrxWallet USD",
+    "symbol": "MUSD",
+    "type": "ERC20",
+    "decimals": 18,
+    "description": "MUSD is the USD-pegged stablecoin of MyrxWallet Network, anchored at 1.00 USD. Used as the primary pricing reference for the MyrxSwap DEX.",
+    "website": "https://myrxwallet.io",
+    "explorer": "https://explorer.myrxwallet.io/address/0x9c5e5b03e5ac5D789e59Ce7D5F6e5e43f8c9BAD2",
+    "status": "active",
+    "id": "0x9c5e5b03e5ac5D789e59Ce7D5F6e5e43f8c9BAD2",
+    "tags": ["stablecoin", "defi", "healthcare"]
+}

--- a/blockchains/myrxwallet/info/info.json
+++ b/blockchains/myrxwallet/info/info.json
@@ -1,0 +1,18 @@
+{
+    "name": "MyrxWallet Network",
+    "website": "https://myrxwallet.io",
+    "description": "Healthcare-focused EVM-compatible blockchain powering prescription management, pharmacy benefits, and DeFi health savings. Native DEX MyrxSwap live on-chain.",
+    "explorer": "https://explorer.myrxwallet.io",
+    "symbol": "MRT",
+    "rpc_url": "https://rpc.myrxwallet.io",
+    "coin_type": 8472,
+    "type": "coin",
+    "decimals": 18,
+    "status": "active",
+    "tags": ["healthcare", "defi", "dapp"],
+    "links": [
+        { "name": "twitter",   "url": "https://twitter.com/myrxwallet" },
+        { "name": "github",    "url": "https://github.com/myrxwallet" },
+        { "name": "whitepaper","url": "https://myrxwallet.io/docs" }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds MyrxWallet Network (Chain 8472) and three tokens to the Trust Wallet asset registry.

**Chain added:**
- `/blockchains/myrxwallet/info/info.json` — MyrxWallet Network, Chain ID 8472, EVM-compatible, MRT native token

**Tokens added:**
- WMRT (Wrapped MRT) — `0x00e69754c21090d69D29a2abe3B6CF153D3F1dF7` — ERC20, 18 decimals
- MUSD (MyrxWallet USD) — `0x9c5e5b03e5ac5D789e59Ce7D5F6e5e43f8c9BAD2` — USD stablecoin, 18 decimals
- WBTC (Wrapped Bitcoin) — `0x4dE82fE635bEA34D9de0C18E49bEE39E8B46c4dF` — ERC20, 8 decimals

**About MyrxWallet Network:**
Healthcare-focused EVM-compatible blockchain. Powers prescription management, pharmacy benefits, and DeFi health savings. Native DEX (MyrxSwap) live on-chain.

- Website: https://myrxwallet.io
- Explorer: https://explorer.myrxwallet.io
- RPC: https://rpc.myrxwallet.io
- Twitter: https://twitter.com/myrxwallet
