### PR TITLE
Mark Wien Euro Reserve Coin (WERC) in Ethereum as HONEYPOT

### DIFF
--- a/blockchains/ethereum/assets/0x9f756bD47c34211c5Ac6AC5358fF9E5afD3db8AE/info.json
+++ b/blockchains/ethereum/assets/0x9f756bD47c34211c5Ac6AC5358fF9E5afD3db8AE/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "HONEYPOT Wien Euro Reserve Coin",
+    "type": "ERC20",
+    "symbol": "HONEYPOT WERC",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://etherscan.io/token/0x9f756bD47c34211c5Ac6AC5358fF9E5afD3db8AE",
+    "explorer": "https://etherscan.io/token/0x9f756bD47c34211c5Ac6AC5358fF9E5afD3db8AE",
+    "status": "spam",
+    "id": "0x9f756bD47c34211c5Ac6AC5358fF9E5afD3db8AE"
+}


### PR DESCRIPTION
[sc-134143]
## Token Marked as HONEYPOT

This PR marks the token as malicious.

- **Name**: HONEYPOT Wien Euro Reserve Coin
- **Symbol**: HONEYPOT WERC
- **Type**: HONEYPOT
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags