### PR TITLE
Mark Tedra USD 2.0 (USD.T) in Ethereum as FAKE

### DIFF
--- a/blockchains/ethereum/assets/0x6d011934C23B44559F237bF4C28A8919906C5955/info.json
+++ b/blockchains/ethereum/assets/0x6d011934C23B44559F237bF4C28A8919906C5955/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE Tedra USD 2.0",
+    "type": "ERC20",
+    "symbol": "FAKE USD.T",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://etherscan.io/token/0x6d011934C23B44559F237bF4C28A8919906C5955",
+    "explorer": "https://etherscan.io/token/0x6d011934C23B44559F237bF4C28A8919906C5955",
+    "status": "spam",
+    "id": "0x6d011934C23B44559F237bF4C28A8919906C5955"
+}


### PR DESCRIPTION
[sc-138192]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE Tedra USD 2.0
- **Symbol**: FAKE USD.T
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags