### PR TITLE
Mark FAKE Tether USD (FAKE USDT) in Smartchain as FAKE

### DIFF
--- a/blockchains/smartchain/assets/0x2A8e74f2aaA893B23bb3373A676aB8f6e7408888/info.json
+++ b/blockchains/smartchain/assets/0x2A8e74f2aaA893B23bb3373A676aB8f6e7408888/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE FAKE Tether USD",
+    "type": "BEP20",
+    "symbol": "FAKE FAKE USDT",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://bscscan.com/token/0x2A8e74f2aaA893B23bb3373A676aB8f6e7408888",
+    "explorer": "https://bscscan.com/token/0x2A8e74f2aaA893B23bb3373A676aB8f6e7408888",
+    "status": "spam",
+    "id": "0x2A8e74f2aaA893B23bb3373A676aB8f6e7408888"
+}


### PR DESCRIPTION
[sc-138240]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE FAKE Tether USD
- **Symbol**: FAKE FAKE USDT
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags