### PR TITLE
Rename Centrifuge to Wrapped Centrifuge (WCFG)

### DIFF
--- a/blockchains/ethereum/assets/0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0/info.json
+++ b/blockchains/ethereum/assets/0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0/info.json
@@ -1,10 +1,10 @@
 {
-    "name": "Centrifuge",
+    "name": "Wrapped Centrifuge",
     "type": "ERC20",
-    "symbol": "CFG",
+    "symbol": "WCFG",
     "decimals": 18,
     "website": "https://centrifuge.io/",
-    "description": "The Centrifuge Token (CFG) guides the development of Centrifuge using an onchain governance mechanism. This is an ERC20 wrapped token of CFG deployed on Ethereum and backed 1:1 by CFG on Centrifuge Chain.",
+    "description": "Wrapped Centrifuge (WCFG) serves as a bridge between real-world assets and the decentralized finance (DeFi) ecosystem. This cryptocurrency token represents Centrifuge on the Ethereum blockchain, enabling users to engage with Centrifuge's offerings within Ethereum's extensive network.",
     "explorer": "https://etherscan.io/token/0xc221b7e65ffc80de234bbb6667abdd46593d34f0",
     "status": "abandoned",
     "id": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0",


### PR DESCRIPTION
Update the abandoned ERC20 token (0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0) on Ethereum:

- Rename "Centrifuge" to "Wrapped Centrifuge"
- Change symbol from CFG to WCFG
- Update description to reflect the wrapped token's role as a bridge to Ethereum DeFi

[sc-143439]