### PR TITLE
Mark Tеthеr (ՍSDT) in Smartchain as FAKE

### DIFF
--- a/blockchains/smartchain/assets/0x4B17cA4C84cA6654b2c852848D73B10a5aAF8888/info.json
+++ b/blockchains/smartchain/assets/0x4B17cA4C84cA6654b2c852848D73B10a5aAF8888/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE Tеthеr",
+    "type": "BEP20",
+    "symbol": "FAKE ՍSDT",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://bscscan.com/token/0x4B17cA4C84cA6654b2c852848D73B10a5aAF8888",
+    "explorer": "https://bscscan.com/token/0x4B17cA4C84cA6654b2c852848D73B10a5aAF8888",
+    "status": "spam",
+    "id": "0x4B17cA4C84cA6654b2c852848D73B10a5aAF8888"
+}


### PR DESCRIPTION
[sc-145675]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE Tеthеr
- **Symbol**: FAKE ՍSDT
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags