### PR TITLE
USD1: normalize description + fix Aptos explorer URL

### DIFF
--- a/blockchains/aptos/assets/0x05fabd1b12e39967a3c24e91b7b8f67719a6dacee74f3c8b9fb7d93e855437d2/info.json
+++ b/blockchains/aptos/assets/0x05fabd1b12e39967a3c24e91b7b8f67719a6dacee74f3c8b9fb7d93e855437d2/info.json
@@ -3,9 +3,9 @@
     "type": "APTOS",
     "symbol": "USD1",
     "decimals": 6,
-    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the US dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
+    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the U.S. dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
     "website": "https://www.worldlibertyfinancial.com/",
-    "explorer": "https://explorer.aptoslabs.com",
+    "explorer": "https://explorer.aptoslabs.com/fungible_asset/0x05fabd1b12e39967a3c24e91b7b8f67719a6dacee74f3c8b9fb7d93e855437d2?network=mainnet",
     "status": "active",
     "id": "0x05fabd1b12e39967a3c24e91b7b8f67719a6dacee74f3c8b9fb7d93e855437d2",
     "links": [

--- a/blockchains/ethereum/assets/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d/info.json
+++ b/blockchains/ethereum/assets/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d/info.json
@@ -3,7 +3,7 @@
     "type": "ERC20",
     "symbol": "USD1",
     "decimals": 18,
-    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the US dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
+    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the U.S. dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
     "website": "https://www.worldlibertyfinancial.com/",
     "explorer": "https://etherscan.io/token/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d",
     "status": "active",

--- a/blockchains/smartchain/assets/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d/info.json
+++ b/blockchains/smartchain/assets/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d/info.json
@@ -3,7 +3,7 @@
     "type": "BEP20",
     "symbol": "USD1",
     "decimals": 18,
-    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the US dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
+    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the U.S. dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
     "website": "https://www.worldlibertyfinancial.com/",
     "explorer": "https://bscscan.com/token/0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d",
     "status": "active",

--- a/blockchains/solana/assets/USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB/info.json
+++ b/blockchains/solana/assets/USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB/info.json
@@ -3,7 +3,7 @@
     "type": "SPL",
     "symbol": "USD1",
     "decimals": 6,
-    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the US dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
+    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the U.S. dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
     "website": "https://www.worldlibertyfinancial.com/",
     "explorer": "https://solscan.io/token/USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB",
     "status": "active",

--- a/blockchains/tron/assets/TPFqcBAaaUMCSVRCqPaQ9QnzKhmuoLR6Rc/info.json
+++ b/blockchains/tron/assets/TPFqcBAaaUMCSVRCqPaQ9QnzKhmuoLR6Rc/info.json
@@ -3,7 +3,7 @@
     "type": "TRC20",
     "symbol": "USD1",
     "decimals": 18,
-    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the US dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
+    "description": "A stablecoin by World Liberty Financial, redeemable 1:1 for the U.S. dollar and backed by U.S. treasuries, dollar deposits, and other cash equivalents.",
     "website": "https://www.worldlibertyfinancial.com/",
     "explorer": "https://tronscan.org/#/token20/TPFqcBAaaUMCSVRCqPaQ9QnzKhmuoLR6Rc",
     "status": "active",


### PR DESCRIPTION
Re-enable legit USD1 after the backend counterfeit-detector fix (backend-assets sc-147563). Touches all 5 USD1 info.json to trigger the collector re-sync; Aptos explorer corrected to the token's fungible_asset page (verified on Aptos mainnet). Refs sc-147563, sc-135753.