### PR TITLE
Create info.json for FAKE Tether token

### DIFF
--- a/blockchains/solana/assets/JAbVkxG3CqfWsbTcHoDobbi5LmGpS4UVf2dY14nPYcvW/info.json
+++ b/blockchains/solana/assets/JAbVkxG3CqfWsbTcHoDobbi5LmGpS4UVf2dY14nPYcvW/info.json
@@ -1,0 +1,11 @@
+{
+  "name": "FAKE Tether",
+  "type": "SPL",
+  "symbol": "FAKE USDT",
+  "decimals": 9,
+  "description": "This token is malicious do not interact",
+  "website": "https://solscan.io/token/JAbVkxG3CqfWsbTcHoDobbi5LmGpS4UVf2dY14nPYcvW",
+  "explorer": "https://solscan.io/token/JAbVkxG3CqfWsbTcHoDobbi5LmGpS4UVf2dY14nPYcvW",
+  "status": "spam",
+  "id": "JAbVkxG3CqfWsbTcHoDobbi5LmGpS4UVf2dY14nPYcvW"
+}


### PR DESCRIPTION
This token impersonates Tether (USDT) using homoglyph characters (letters from 
Armenian, Cyrillic, and Cherokee alphabets that visually mimic Latin letters) 
in both its name and symbol. Marking as spam to prevent users from being 
deceived, similar to PR #37342 and #37353.

Address: JAbVkxG3CqfWsbTcHoDobbi5LmGpS4UVf2dY14nPYcvW
Explorer: https://solscan.io/token/JAbVkxG3CqfWsbTcHoDobbi5LmGpS4UVf2dY14nPYcvW

Token created 21 days ago and is currently displayed across multiple wallets 
under a name visually indistinguishable from real USDT.