### PR TITLE
Mark FAKE ꓐitcoin (FAKE ꓐꓔꓚ) in Smartchain as FAKE

### DIFF
--- a/blockchains/smartchain/assets/0xfe232C02aFb2aB98510883D8AE1A414069C48888/info.json
+++ b/blockchains/smartchain/assets/0xfe232C02aFb2aB98510883D8AE1A414069C48888/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE FAKE ꓐitcoin",
+    "type": "BEP20",
+    "symbol": "FAKE FAKE ꓐꓔꓚ",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://bscscan.com/token/0xfe232C02aFb2aB98510883D8AE1A414069C48888",
+    "explorer": "https://bscscan.com/token/0xfe232C02aFb2aB98510883D8AE1A414069C48888",
+    "status": "spam",
+    "id": "0xfe232C02aFb2aB98510883D8AE1A414069C48888"
+}


### PR DESCRIPTION
[sc-151910]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE FAKE ꓐitcoin
- **Symbol**: FAKE FAKE ꓐꓔꓚ
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags