### PR TITLE
Mark Tether USD (USDT) in Smartchain as FAKE

### DIFF
--- a/blockchains/smartchain/assets/0x6C652Ae01cac574e5a9EE39dcBC9E1Fb29BD8888/info.json
+++ b/blockchains/smartchain/assets/0x6C652Ae01cac574e5a9EE39dcBC9E1Fb29BD8888/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE Tether USD",
+    "type": "BEP20",
+    "symbol": "FAKE USDT",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://bscscan.com/token/0x6C652Ae01cac574e5a9EE39dcBC9E1Fb29BD8888",
+    "explorer": "https://bscscan.com/token/0x6C652Ae01cac574e5a9EE39dcBC9E1Fb29BD8888",
+    "status": "spam",
+    "id": "0x6C652Ae01cac574e5a9EE39dcBC9E1Fb29BD8888"
+}


### PR DESCRIPTION
[sc-152250]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE Tether USD
- **Symbol**: FAKE USDT
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags