### PR TITLE
Mark USDT (USDT) in Ethereum as FAKE

### DIFF
--- a/blockchains/ethereum/assets/0xfCe67Fb5155F2e0da98bf32e3Cc824aF2A08f3CA/info.json
+++ b/blockchains/ethereum/assets/0xfCe67Fb5155F2e0da98bf32e3Cc824aF2A08f3CA/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE USDT",
+    "type": "ERC20",
+    "symbol": "FAKE USDT",
+    "decimals": 5,
+    "description": "This token is malicious do not interact",
+    "website": "https://etherscan.io/token/0xfCe67Fb5155F2e0da98bf32e3Cc824aF2A08f3CA",
+    "explorer": "https://etherscan.io/token/0xfCe67Fb5155F2e0da98bf32e3Cc824aF2A08f3CA",
+    "status": "spam",
+    "id": "0xfCe67Fb5155F2e0da98bf32e3Cc824aF2A08f3CA"
+}


### PR DESCRIPTION
[sc-154335]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE USDT
- **Symbol**: FAKE USDT
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags