### PR TITLE
Mark USDT (USDT) in Tron as FAKE

### DIFF
--- a/blockchains/tron/assets/TPaFUmTSHvvj1CTvxcX6WVFx5XhuoNs1aQ/info.json
+++ b/blockchains/tron/assets/TPaFUmTSHvvj1CTvxcX6WVFx5XhuoNs1aQ/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE USDT",
+    "type": "TRC20",
+    "symbol": "FAKE USDT",
+    "decimals": 6,
+    "description": "This token is malicious do not interact",
+    "website": "https://tronscan.org/#/token20/TPaFUmTSHvvj1CTvxcX6WVFx5XhuoNs1aQ",
+    "explorer": "https://tronscan.org/#/token20/TPaFUmTSHvvj1CTvxcX6WVFx5XhuoNs1aQ",
+    "status": "spam",
+    "id": "TPaFUmTSHvvj1CTvxcX6WVFx5XhuoNs1aQ"
+}


### PR DESCRIPTION
[sc-154352]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE USDT
- **Symbol**: FAKE USDT
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags