### PR TITLE
Update CodeQL workflow actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,6 +58,6 @@ jobs:
       run: make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

- update actions/checkout from v3 to v7
- update github/codeql-action init and analyze from v2 to v4
- preserve the existing triggers, permissions, language matrix, and manual build flow

## Why

The current scheduled CodeQL run completes, but it reports that CodeQL Action v2 is deprecated and that checkout v3 plus CodeQL v2 are Node 20 actions being forced onto Node 24:
https://github.com/trustwallet/assets/actions/runs/31907785397

The updated major tags use the supported Node 24 runtime and remove those warnings without changing workflow behavior.

## Validation

- parsed the workflow as YAML
- verified the official v7 and v4 action tags and Node 24 runtimes
- git diff --check
- independent standards and scope reviews passed

This PR changes only GitHub Actions workflow configuration; it does not add or modify token assets.

AI-assisted contribution: Codex was used to inspect the workflow run, prepare the narrow version update, and run validation. I reviewed and take responsibility for the final change.