### PR TITLE
Fix Juno fee rate and dead endpoints

### DIFF
--- a/blockchains/juno/info/info.json
+++ b/blockchains/juno/info/info.json
@@ -7,11 +7,11 @@
     "description": "Juno is an interoperable smart contract network. Highly scalable, robust, secure and easy to deploy.",
     "explorer": "https://www.mintscan.io/juno",
     "status": "active",
-    "rpc_url": "https://rpc.juno.interbloc.org",
+    "rpc_url": "https://juno-rpc.publicnode.com",
     "denom": "ujuno",
-    "lcd_url": "https://lcd-juno.itastakers.com",
+    "lcd_url": "https://juno-api.polkachu.com",
     "hrp": "juno",
-    "fee_rate": "0.04",
+    "fee_rate": "0.075",
     "tags": [
         "staking-native"
     ],


### PR DESCRIPTION
## Summary
- raise Juno's configured fee rate from `0.04` to the live v30 minimum base gas price of `0.075ujuno`
- replace two DNS-dead Juno RPC/LCD endpoints with live endpoints returning `juno-1`

## Context
Juno v30 enabled `x/feemarket` with a current minimum base gas price of `0.075ujuno`. Users have reported Trust Wallet sends failing since the upgrade. The existing Trust Wallet asset metadata advertises `0.04`, below the chain minimum, and both configured service hostnames currently fail DNS resolution.

Live chain evidence:
- `/juno/feemarket/v1/gas_prices?denom=ujuno` returns `0.075ujuno`
- replacement RPC and LCD both report chain ID `juno-1`

## Verification
- `jq empty blockchains/juno/info/info.json`
- `go test ./...`
- `make check` — 49,182 files, 0 errors
- replacement RPC/LCD queried successfully for `juno-1`
