### PR TITLE
Mark T℮ther (USDΤ) in Smartchain as FAKE

### DIFF
--- a/blockchains/smartchain/assets/0x5c19a86b6f24c66cAf9372A2627a20C6a4227777/info.json
+++ b/blockchains/smartchain/assets/0x5c19a86b6f24c66cAf9372A2627a20C6a4227777/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE T℮ther",
+    "type": "BEP20",
+    "symbol": "FAKE USDΤ",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://bscscan.com/token/0x5c19a86b6f24c66cAf9372A2627a20C6a4227777",
+    "explorer": "https://bscscan.com/token/0x5c19a86b6f24c66cAf9372A2627a20C6a4227777",
+    "status": "spam",
+    "id": "0x5c19a86b6f24c66cAf9372A2627a20C6a4227777"
+}


### PR DESCRIPTION
[sc-155383]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE T℮ther
- **Symbol**: FAKE USDΤ
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags