### PR TITLE
Mark ՍƧⅮꓔ (ꓴꓢƊꓔ) in Ethereum as FAKE

### DIFF
--- a/blockchains/ethereum/assets/0xdEF5983643517D4F5d3137057178CBc69703C8ae/info.json
+++ b/blockchains/ethereum/assets/0xdEF5983643517D4F5d3137057178CBc69703C8ae/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE ՍƧⅮꓔ",
+    "type": "ERC20",
+    "symbol": "FAKE ꓴꓢƊꓔ",
+    "decimals": 6,
+    "description": "This token is malicious do not interact",
+    "website": "https://etherscan.io/token/0xdEF5983643517D4F5d3137057178CBc69703C8ae",
+    "explorer": "https://etherscan.io/token/0xdEF5983643517D4F5d3137057178CBc69703C8ae",
+    "status": "spam",
+    "id": "0xdEF5983643517D4F5d3137057178CBc69703C8ae"
+}


### PR DESCRIPTION
[sc-156637]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE ՍƧⅮꓔ
- **Symbol**: FAKE ꓴꓢƊꓔ
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags