### PR TITLE
Mark ꓔеther ՍՏⅮ (ՍՏⅮꓔ) in Smartchain as FAKE

### DIFF
--- a/blockchains/smartchain/assets/0x60c909Cb023BC831788F44058251C6a688E18888/info.json
+++ b/blockchains/smartchain/assets/0x60c909Cb023BC831788F44058251C6a688E18888/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE ꓔеther ՍՏⅮ",
+    "type": "BEP20",
+    "symbol": "FAKE ՍՏⅮꓔ",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://bscscan.com/token/0x60c909Cb023BC831788F44058251C6a688E18888",
+    "explorer": "https://bscscan.com/token/0x60c909Cb023BC831788F44058251C6a688E18888",
+    "status": "spam",
+    "id": "0x60c909Cb023BC831788F44058251C6a688E18888"
+}


### PR DESCRIPTION
[sc-156667]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE ꓔеther ՍՏⅮ
- **Symbol**: FAKE ՍՏⅮꓔ
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags