### PR TITLE
Mark fake UZDT contract from PR #37799 as spam / impersonation

### DIFF
--- a/blockchains/ethereum/assets/0x259cE73B7F24D605B0d122E0a81bDc880B8600AF/info.json
+++ b/blockchains/ethereum/assets/0x259cE73B7F24D605B0d122E0a81bDc880B8600AF/info.json
@@ -1,0 +1,8 @@
+{
+  "name": "FAKE UZDT",
+  "symbol": "UZDT",
+  "type": "ERC20",
+  "address": "0x259cE73B7F24D605B0d122E0a81bDc880B8600AF",
+  "decimals": 18,
+  "status": "spam"
+}


### PR DESCRIPTION
Security / impersonation report regarding PR #37799

This pull request is submitted by the official UZDT (Uzbekistan Digital Token) project team.

PR #37799 attempts to associate the Ethereum contract 0x259cE73B7F24D605B0d122E0a81bDc880B8600AF with the UZDT (Uzbekistan Digital Token) project.

This contract is NOT an official UZDT contract and is NOT controlled, deployed, authorized, or endorsed by the UZDT project team.

The submitter of PR #37799 is not authorized to represent UZDT. The submission uses the UZDT project name, symbol, official website (https://uzdtoken.com), and official project resources in connection with an unauthorized contract. This creates a serious risk of impersonation and user confusion.

The official UZDT website publishes the legitimate contract addresses supported by the project:

https://uzdtoken.com/

The legitimate UZDT Ethereum contract can also be independently verified through the official project information and blockchain explorer.

We therefore request that Trust Wallet:

Reject and close PR #37799.
Do not associate 0x259cE73B7F24D605B0d122E0a81bDc880B8600AF with UZDT or uzdtoken.com.
Review this address/submission as an impersonation or spam asset under Trust Wallet's applicable policies.

We can provide additional proof of control of the official website, social accounts, and official contract addresses if required.

Reference: PR #37799

Official UZDT Ethereum contract:
0x603CBE0FCC90262008b30765D7cd9ff504D61a2c
https://etherscan.io/token/0x603CBE0FCC90262008b30765D7cd9ff504D61a2c