### PR TITLE
Mark Tesla - Tokenized on Base (TSLA) in Base as FAKE

### DIFF
--- a/blockchains/base/assets/0x4409D3392019baE6b914A5D92Fbff46fa2aCA368/info.json
+++ b/blockchains/base/assets/0x4409D3392019baE6b914A5D92Fbff46fa2aCA368/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE Tesla - Tokenized on Base",
+    "type": "BASE",
+    "symbol": "FAKE TSLA",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://basescan.org/token/0x4409D3392019baE6b914A5D92Fbff46fa2aCA368",
+    "explorer": "https://basescan.org/token/0x4409D3392019baE6b914A5D92Fbff46fa2aCA368",
+    "status": "spam",
+    "id": "0x4409D3392019baE6b914A5D92Fbff46fa2aCA368"
+}


### PR DESCRIPTION
[sc-159595]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE Tesla - Tokenized on Base
- **Symbol**: FAKE TSLA
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags