### PR TITLE
Mark US͏DT (US͏DT) in Ethereum as FAKE

### DIFF
--- a/blockchains/ethereum/assets/0x86851b32f7bd26C7b3DAfFA32A478F2a1f8fBcC7/info.json
+++ b/blockchains/ethereum/assets/0x86851b32f7bd26C7b3DAfFA32A478F2a1f8fBcC7/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE US͏DT",
+    "type": "ERC20",
+    "symbol": "FAKE US͏DT",
+    "decimals": 6,
+    "description": "This token is malicious do not interact",
+    "website": "https://etherscan.io/token/0x86851b32f7bd26C7b3DAfFA32A478F2a1f8fBcC7",
+    "explorer": "https://etherscan.io/token/0x86851b32f7bd26C7b3DAfFA32A478F2a1f8fBcC7",
+    "status": "spam",
+    "id": "0x86851b32f7bd26C7b3DAfFA32A478F2a1f8fBcC7"
+}


### PR DESCRIPTION
[sc-159770]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE US͏DT
- **Symbol**: FAKE US͏DT
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags