### PR TITLE
Mark U5DT (U5DT) in Smartchain as FAKE

### DIFF
--- a/blockchains/smartchain/assets/0x1EFE61bD4E1581AA9Eab7E5b9885e30f4304bF7F/info.json
+++ b/blockchains/smartchain/assets/0x1EFE61bD4E1581AA9Eab7E5b9885e30f4304bF7F/info.json
@@ -1,0 +1,11 @@
+{
+    "name": "FAKE U5DT",
+    "type": "BEP20",
+    "symbol": "FAKE U5DT",
+    "decimals": 18,
+    "description": "This token is malicious do not interact",
+    "website": "https://bscscan.com/token/0x1EFE61bD4E1581AA9Eab7E5b9885e30f4304bF7F",
+    "explorer": "https://bscscan.com/token/0x1EFE61bD4E1581AA9Eab7E5b9885e30f4304bF7F",
+    "status": "spam",
+    "id": "0x1EFE61bD4E1581AA9Eab7E5b9885e30f4304bF7F"
+}


### PR DESCRIPTION
[sc-161040]
## Token Marked as FAKE

This PR marks the token as malicious.

- **Name**: FAKE U5DT
- **Symbol**: FAKE U5DT
- **Type**: FAKE
- **Status**: spam

### Changes:
- Updated info.json with spam status
- Removed logo.png
- Set website to explorer link
- Removed links and tags